### PR TITLE
Add initial SPEC draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,50 @@
 # cohosting
-A set of light tools and conventions for cohosting public websites and files on IPFS
 
+> Simple tools and conventions for cohosting existing websites with IPFS
 
-## WIP
+## Motivation
 
-This repo will define the SPEC extracted from https://github.com/ipfs-shipyard/ipfs-desktop/issues/1034
+- make it easier for people to contribute storage and bandwidth to sites and datasets they care about
+  - support [IPNS](https://docs.ipfs.io/guides/concepts/ipns/) (libp2p keys) and [DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/) roots (human-readable)
+- periodically detect updates to and preload them to a local node
+- experiment in userland: make it easy to implement, no new APIs, reuse existing ones
+
+## Specification
+
+See [SPEC.md](SPEC.md)
+
+## Implementations
+
+🍎 = Not started  
+🍊 = In progress  
+🍏 = Complete
+
+### ipfs-shipyard
+
+#### 🍎 [cohosting.sh](cohosting.sh)
+> MVP bash script that can be used for cli
+
+  - [ ] `add` `rm` for adding / removing sites to cohosting list via commandline
+  - [ ] `sync` a command to run cohosting check for use in crond  
+  - [ ] `gc <n>` drop all old snapshots (if `n` is provided, keeps that many snapshots per site)
+
+#### 🍎 [ipfs-cohost](https://github.com/olizilla/ipfs-cohost)
+> NPM-based interactive cli tool
+
+  - [ ] switch from `pin` to MFS-based spec
+
+#### 🍎 [ipfs-companion](https://github.com/ipfs-shipyard/ipfs-companion)
+  > browser extension
+
+  - [ ] provides UI for adding / removing sites via browser action menu
+  - [ ] runs cohosting check periodically
+
+#### 🍎 [ipfs-desktop](https://github.com/ipfs-shipyard/ipfs-desktop)
+  > desktop app and GUI for managing go-ipfs
+
+  - [ ] runs cohosting check periodically
+
+#### 🍎 [ipfs-webui](https://github.com/ipfs-shipyard/ipfs-webui)
+  > web frontend for IPFS node
+  
+  - [ ] provides UI for adding / removing sites to cohosting list as an experiment on _Settings_ page

--- a/README.md
+++ b/README.md
@@ -1,31 +1,41 @@
-# cohosting
+# Experiment in MFS-based cohosting
 
-> Simple tools and conventions for cohosting existing websites with IPFS
+> Exploration around simple tools and conventions for cohosting existing websites with IPFS
 
 ## Motivation
 
-- make it easier for people to contribute storage and bandwidth to sites and datasets they care about
-  - support [IPNS](https://docs.ipfs.io/guides/concepts/ipns/) (libp2p keys) and [DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/) roots (human-readable)
-- periodically detect updates to and preload them to a local node
-- experiment in userland: make it easy to implement, no new APIs, reuse existing ones
+- Make it easier for people to contribute storage and bandwidth to sites and datasets they care about
+  - Support [IPNS](https://docs.ipfs.io/guides/concepts/ipns/) (libp2p keys) and [DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/) roots (human-readable)
+  - Switch tools like ipfs-cohost and ipfs-companion from raw pins to MFS
+- Periodically detect updates to and preload them to a local node
+- Experiment in userland: make it easy to implement, no new APIs, reuse existing ones
+  - Identify constraints of the [mutable filesystem (MFS)](https://docs.ipfs.io/guides/concepts/mfs/) and propose ways to improve it
+
+### Scope vs. Use Cases
+
+See [this analysis](https://github.com/ipfs-shipyard/cohosting/pull/2#issuecomment-524288790).
 
 ## Specification
 
 See [SPEC.md](SPEC.md)
 
-## Implementations
+> ### 🚧 note: this is a draft, an early, exploratory experiment 🚧
+> Feedback is welcome. Fill an issue!
+
+## Potential Implementations
+
+This specification is not implemented yet.
+The following [IPFS Shipyard](https://github.com/ipfs-shipyard/) projects could implement it:
 
 🍎 = Not started  
 🍊 = In progress  
 🍏 = Complete
 
-### ipfs-shipyard
-
 #### 🍎 [cohosting.sh](cohosting.sh)
 > MVP bash script that can be used for cli
 
   - [ ] `add` `rm` for adding / removing sites to cohosting list via commandline
-  - [ ] `sync` a command to run cohosting check for use in crond  
+  - [ ] `sync` a command to run cohosting check (for use in `crond` etc)
   - [ ] `gc <n>` drop all old snapshots (if `n` is provided, keeps that many snapshots per site)
 
 #### 🍎 [ipfs-cohost](https://github.com/olizilla/ipfs-cohost)
@@ -46,5 +56,5 @@ See [SPEC.md](SPEC.md)
 
 #### 🍎 [ipfs-webui](https://github.com/ipfs-shipyard/ipfs-webui)
   > web frontend for IPFS node
-  
+
   - [ ] provides UI for adding / removing sites to cohosting list as an experiment on _Settings_ page

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,4 +1,13 @@
-# cohosting SPEC
+
+
+# MFS cohosting SPEC (experimental draft)
+
+> ### 🚧 this is not an official specification, just an early, exploratory experiment 🚧
+>
+> The goal is to see what is possible with the [mutable filesystem (MFS)](https://docs.ipfs.io/guides/concepts/mfs/), and what could be possible if we extend it.
+>
+> ⚠️ Feedback is welcome, PR or fill an issue!  ⚠️
+
 
 * [Site identifiers](#site-identifiers)
 * [Path conventions](#path-conventions)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,83 @@
+# cohosting SPEC
+
+* [Site identifiers](#site-identifiers)
+* [Path conventions](#path-conventions)
+* [Operations](#operations)
+  * [Adding](#adding)
+  * [Removing](#removing)
+  * [Updating](#updating)
+
+
+## Site identifiers
+
+`/ipns/<site-id>` is a mutable pointer to immutable data.
+
+Currently supported pointers:
+- [CID](https://docs.ipfs.io/guides/concepts/cid/) of libp2p-key used by an   [IPNS](https://docs.ipfs.io/guides/concepts/ipns/) site (`/ipns/<libp2p-key>`)
+- [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) with a [DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/) (`/ipns/<domain-name>`)
+
+## Path conventions
+
+- `/cohosting` - presence of directory in MFS root enables cohosting logic
+- `/cohosting/<site-id>` - presence of directory enables update checks for this site
+- `/cohosting/<site-id>/<timestamp>` - site snapshot at a point in time
+  - `<timestamp>` format is `YYYY-MM-DD_hhmmss`  (zero-padded [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) in UTC)
+
+## Operations
+
+Below is a complete list of all operations needed for implementing this spec.  
+One can execute commands manually in shell or automate everything using programmatic interfaces.
+
+Note: the following examples use `docs.ipfs.io` as a `<site-id>`
+
+### Adding
+
+```console
+$ ipfs files mkdir -p /cohosting/docs.ipfs.io
+```
+
+### Removing
+
+```console
+$ ipfs files rm  /cohosting/docs.ipfs.io
+```
+
+### Updating
+
+1. Get the list of cohosted sites
+   ```console
+   $ ipfs files ls /cohosting
+   docs.ipfs.io
+   libp2p.io
+   multiformats.io
+   ```
+   Next: execute following steps for each `<site-id>`:
+
+2. List existing snapshots, sort them lexicographically and read timestamp of the latest one
+   ```console
+   $ ipfs files ls /cohosting/docs.ipfs.io | sort | head -1
+   2019-08-22_150420
+   ```
+   If timestamp is older than 12 hours, remember it and continue to step 3.
+   Otherwise, do nothing and move to the next site.
+
+3. Find the current CID of checked site
+   ```console
+   $ ipfs resolve -r /ipns/docs.ipfs.io
+   /ipfs/Qmd41WqbCsfTx4wJvP6vvv3hHb46bEHG1hC6Kqt7mhGQUR
+   ```
+
+4. Copy it to MFS using current UTC time as `<timestamp>`
+   ```console
+   $ ipfs files cp /ipfs/Qmd41WqbCsfTx4wJvP6vvv3hHb46bEHG1hC6Kqt7mhGQUR /cohosting/docs.ipfs.io/2019-08-22_153940
+   ```
+5. (optional) Drop the previous snapshot (identified in step 2) if it points at the same CID
+   * read the CID of the previous snapshot:
+      ```console
+      $ ipfs files stat /cohosting/docs.ipfs.io/2019-08-22_153940 | head -1
+      Qmd41WqbCsfTx4wJvP6vvv3hHb46bEHG1hC6Kqt7mhGQUR
+      ```
+   * if the CID is the same as one from step 3, remove the snapshot (do nothing otherwise):
+     ```console
+     $  ipfs files rm /cohosting/docs.ipfs.io/2019-08-22_153940
+     ```

--- a/cohosting.sh
+++ b/cohosting.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
 
+# not implemented, but feel free to PR :-)
+
 # TODO fail when ipfs is not on PATH
 # TODO add
 # TODO rm

--- a/cohosting.sh
+++ b/cohosting.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+
+# TODO fail when ipfs is not on PATH
+# TODO add
+# TODO rm
+# TODO update
+# TODO gc


### PR DESCRIPTION
This PR proposes a simple spec for MFS-based cohosting scheme suggested in https://github.com/ipfs-shipyard/ipfs-desktop/issues/1034.


## Motivation

- make it easier for people to contribute storage and bandwidth to sites and datasets they care about
  - support [IPNS](https://docs.ipfs.io/guides/concepts/ipns/) (libp2p keys) and [DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/) roots (human-readable)
- make it easy to implement in companion, desktop and webui
- periodically detect updates to and preload them to a local node


## TL;DR

- proposed scheme does not introduce any config files, path convention is used instead
  - `/cohosting` - presence of directory in MFS root enables cohosting logic
  - `/cohosting/<site-id>` - presence of directory enables update checks for this site
  - `/cohosting/<site-id>/<timestamp>` - site snapshot at a point in time
- Files API is all one needs to manage cohosted websites:
  - `ipfs files ls /cohosting/` returns a list of cohosted websites
  - `ipfs files mkdir -p /cohosting/docs.ipfs.io` adds a website to cohosting list
  - `ipfs files rm -r /cohosting/docs.ipfs.io` stops cohosting of a site
- a periodic check every 12h can be done by multiple apps without duplicated work
- MFS takes care of keeping snapshot around (protecting from GC)
- User can browse and manage cohosted snapshots via Web UI's _Files_ screen