### PR TITLE
feat: add cohosting.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ The following [IPFS Shipyard](https://github.com/ipfs-shipyard/) projects could 
 🍊 = In progress  
 🍏 = Complete
 
-#### 🍎 [cohosting.sh](cohosting.sh)
+#### 🍏 [cohosting.sh](cohosting.sh)
 > MVP bash script that can be used for cli
 
-  - [ ] `add` `rm` for adding / removing sites to cohosting list via commandline
-  - [ ] `sync` a command to run cohosting check (for use in `crond` etc)
-  - [ ] `gc <n>` drop all old snapshots (if `n` is provided, keeps that many snapshots per site)
+  - [x] `add` `rm` for adding / removing sites to cohosting list via commandline
+  - [x] `sync` a command to run cohosting check (for use in `crond` etc)
+  - [x] `gc [n]` drop all old snapshots (if `n` is provided, keeps that many snapshots per site)
 
 #### 🍎 [ipfs-cohost](https://github.com/olizilla/ipfs-cohost)
 > NPM-based interactive cli tool

--- a/cohosting.sh
+++ b/cohosting.sh
@@ -53,7 +53,9 @@ if [ "$1" = "add" ]; then
   shift 1
 
   for domain in "$@"; do
+    echo -n "Adding $domain..."
     update $domain
+    echo " done!"
   done
 
   exit 0
@@ -67,7 +69,9 @@ if [ "$1" = "rm" ]; then
   shift 1
 
   for domain in "$@"; do
+    echo -n "Removing $domain..."
     remove $domain
+    echo " done!"
   done
 
   exit 0
@@ -90,7 +94,9 @@ fi
 
 if [ "$1" = "sync" ]; then
   ipfs files ls /cohosting | while read domain; do
+    echo -n "Syncing $domain..."
     update $domain
+    echo " done!"
   done
   exit 0
 fi
@@ -98,8 +104,10 @@ fi
 if [ "$1" = "gc" ]; then
   if [ $# -eq 1 ]; then
     ipfs files ls /cohosting | while read domain; do
+      echo -n "Cleaning $domain..."
       remove $domain
       ipfs files mkdir -p "/cohosting/$domain"
+      echo " done!"
     done
     exit 0
   fi
@@ -109,8 +117,10 @@ if [ "$1" = "gc" ]; then
   fi
 
   ipfs files ls /cohosting | while read domain; do
+    echo -n "Cleaning $domain..."
     ipfs files ls "/cohosting/$domain" | tail -r | tail -n "+$2" | while read snap; do
       ipfs files rm -rf "/cohosting/$domain/$snap"
     done
+    echo " done!"
   done
 fi

--- a/cohosting.sh
+++ b/cohosting.sh
@@ -1,10 +1,115 @@
 #!/bin/bash
 set -eu
 
-# not implemented, but feel free to PR :-)
+usage () {
+  echo "Usage:"
+  echo -e "\t$0 add <domain>..."
+  echo -e "\t$0 rm <domain>..."
+  echo -e "\t$0 ls [domain]..."
+  echo -e "\t$0 sync"
+  echo -e "\t$0 gc [n]"
+  exit 1
+}
 
-# TODO fail when ipfs is not on PATH
-# TODO add
-# TODO rm
-# TODO update
-# TODO gc
+update () {
+  domain=$1
+  cid=$(ipfs resolve "/ipns/$1")
+  path="/cohosting/$domain"
+
+  ipfs files mkdir -p $path
+  latest=$(ipfs files ls $path | sort | head -1)
+
+  if [ ! "$latest" = "" ]; then
+    latest_cid=$(ipfs files stat "$path/$latest" | head -1)
+
+    if [ "/ipfs/$latest_cid" = "$cid" ]; then
+      ipfs files mv "$path/$latest" "$path/$(date -u +"%Y-%m-%d_%H%M%S")"
+      exit 0
+    fi
+  fi
+
+  ipfs files cp $cid "$path/$(date -u +"%Y-%m-%d_%H%M%S")"
+}
+
+remove () {
+  ipfs files rm -rf "/cohosting/$1"
+}
+
+if ! [ -x "$(command -v ipfs)" ]; then
+  echo "Error: ipfs is not installed."
+  exit 1
+fi
+
+if [ $# -eq 0 ]; then
+  usage
+fi
+
+if [ "$1" = "add" ]; then
+  if [ $# -lt 2 ]; then
+    usage
+  fi
+
+  shift 1
+
+  for domain in "$@"; do
+    update $domain
+  done
+
+  exit 0
+fi
+
+if [ "$1" = "rm" ]; then
+  if [ $# -lt 2 ]; then
+   usage
+  fi
+
+  shift 1
+
+  for domain in "$@"; do
+    remove $domain
+  done
+
+  exit 0
+fi
+
+if [ "$1" = "ls" ]; then
+  if [ $# -lt 2 ]; then
+    ipfs files ls /cohosting
+    exit 0
+  fi
+
+  shift 1
+
+  for domain in "$@"; do
+    echo "snapshots for $domain"
+    ipfs files ls "/cohosting/$domain"
+  done
+  exit 0
+fi
+
+if [ "$1" = "sync" ]; then
+  ipfs files ls /cohosting | while read domain; do
+    update $domain
+  done
+  exit 0
+fi
+
+if [ "$1" = "gc" ]; then
+  if [ $# -eq 1 ]; then
+    ipfs files ls /cohosting | while read domain; do
+      remove $domain
+      ipfs files mkdir -p "/cohosting/$domain"
+    done
+    exit 0
+  fi
+
+  if [ ! $# -eq 2 ]; then
+    usage
+  fi
+
+  ipfs files ls /cohosting | while read domain; do
+    ipfs files ls "/cohosting/$domain" | tail -r | tail -n "+$2" | while read snap; do
+      ipfs files rm -rf "/cohosting/$domain/$snap"
+    done
+  done
+fi

--- a/cohosting.sh
+++ b/cohosting.sh
@@ -24,7 +24,7 @@ update () {
 
     if [ "/ipfs/$latest_cid" = "$cid" ]; then
       ipfs files mv "$path/$latest" "$path/$(date -u +"%Y-%m-%d_%H%M%S")"
-      exit 0
+      return
     fi
   fi
 

--- a/cohosting.sh
+++ b/cohosting.sh
@@ -28,6 +28,7 @@ update () {
     fi
   fi
 
+  ipfs refs --recursive $cid > /dev/null
   ipfs files cp $cid "$path/$(date -u +"%Y-%m-%d_%H%M%S")"
 }
 


### PR DESCRIPTION
So here's a first iteration of `cohosting.sh` with the following usage:

```
Usage:
	./cohosting.sh add <domain>...
	./cohosting.sh rm <domain>...
	./cohosting.sh ls [domain]...
	./cohosting.sh sync
	./cohosting.sh gc [n]
```

`<arg>` for mandatory arguments. `[arg]` for optional ones. Not sure if that's correct.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>